### PR TITLE
User options

### DIFF
--- a/JPetCmdParser/JPetCmdParser.cpp
+++ b/JPetCmdParser/JPetCmdParser.cpp
@@ -35,7 +35,7 @@ JPetCmdParser::JPetCmdParser(): fOptionsDescriptions("Allowed options")
   ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
   ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
   ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")
-  ("userCfg,j", po::value<std::string>(), "Json file with optional user parameters.");
+  ("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.");
 }
 
 JPetCmdParser::~JPetCmdParser()

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -353,7 +353,8 @@ BOOST_AUTO_TEST_CASE(checkWrongOutputPath)
   ("runId,i", po::value<int>(), "Run id.")
   ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
   ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
-  ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.");
+  ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")
+  ("userCfg,j", po::value<std::string>(), "Json file with optional user parameters.");
 
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
@@ -372,8 +373,8 @@ BOOST_AUTO_TEST_CASE(checkOptionsWithAddedFromJson)
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
   auto option = options.at(0);
   auto allOptions = option.getOptions();
-  BOOST_REQUIRE(allOptions.count("myOption"));
-  BOOST_REQUIRE_EQUAL(allOptions.at("myOption"), "great");
+  BOOST_REQUIRE(allOptions.count("MyOption"));
+  BOOST_REQUIRE_EQUAL(allOptions.at("MyOption"), "great");
   BOOST_REQUIRE(allOptions.count("myAnotherOption"));
   BOOST_REQUIRE_EQUAL(allOptions.at("myAnotherOption"), "wat");
   BOOST_REQUIRE(allOptions.count("boolOption"));

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(checkWrongOutputPath)
   ("progressBar,b", po::bool_switch()->default_value(false), "Progress bar.")
   ("localDB,l", po::value<std::string>(), "The file to use as the parameter database.")
   ("localDBCreate,L", po::value<std::string>(), "File name to which the parameter database will be saved.")
-  ("userCfg,j", po::value<std::string>(), "Json file with optional user parameters.");
+  ("userCfg,u", po::value<std::string>(), "Json file with optional user parameters.");
 
   po::variables_map variablesMap;
   po::store(po::parse_command_line(argc, argv, description), variablesMap);
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(checkWrongOutputPath)
 
 BOOST_AUTO_TEST_CASE(checkOptionsWithAddedFromJson)
 {
-  auto args_char = createArgs("main.x -o ./ -f unitTestData/JPetCmdParserTest/data.hld -t hld -j unitTestData/JPetOptionsToolsTest/inputTestCfg.json");
+  auto args_char = createArgs("main.x -o ./ -f unitTestData/JPetCmdParserTest/data.hld -t hld -u unitTestData/JPetOptionsToolsTest/inputTestCfg.json");
   auto argc = args_char.size();
   auto argv = args_char.data();
 

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(checkOptionsWithAddedFromJson)
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
   auto option = options.at(0);
   auto allOptions = option.getOptions();
-  BOOST_REQUIRE(allOptions.count("MyOption"));
+  BOOST_REQUIRE_EQUAL(allOptions.count("MyOption"), 1);
   BOOST_REQUIRE_EQUAL(allOptions.at("MyOption"), "great");
   BOOST_REQUIRE(allOptions.count("myAnotherOption"));
   BOOST_REQUIRE_EQUAL(allOptions.at("myAnotherOption"), "wat");

--- a/JPetCmdParser/JPetCmdParserTest.cpp
+++ b/JPetCmdParser/JPetCmdParserTest.cpp
@@ -373,8 +373,8 @@ BOOST_AUTO_TEST_CASE(checkOptionsWithAddedFromJson)
   auto options = parser.parseAndGenerateOptions(argc, const_cast<const char**>(argv));
   auto option = options.at(0);
   auto allOptions = option.getOptions();
-  BOOST_REQUIRE_EQUAL(allOptions.count("MyOption"), 1);
-  BOOST_REQUIRE_EQUAL(allOptions.at("MyOption"), "great");
+  BOOST_REQUIRE_EQUAL(allOptions.count("myOption"), 1);
+  BOOST_REQUIRE_EQUAL(allOptions.at("myOption"), "great");
   BOOST_REQUIRE(allOptions.count("myAnotherOption"));
   BOOST_REQUIRE_EQUAL(allOptions.at("myAnotherOption"), "wat");
   BOOST_REQUIRE(allOptions.count("boolOption"));

--- a/JPetOptions/JPetOptionsTools.cpp
+++ b/JPetOptions/JPetOptionsTools.cpp
@@ -42,7 +42,7 @@ bool createConfigFileFromOptions(const Options& options, const std::string& outF
 Options createOptionsFromConfFile(const std::string& filename)
 {
   pt::ptree optionsTree;
-  Options mapOptions;
+  Options mapOptions, emptyMap;
   if (JPetCommonTools::ifFileExisting(filename)) {
     try {
       pt::read_json(filename, optionsTree);
@@ -53,6 +53,7 @@ Options createOptionsFromConfFile(const std::string& filename)
       }
     } catch (pt::json_parser_error) {
       ERROR("ERROR IN READINIG OPTIONS FROM JSON FILE! FILENAME:" + filename );
+      return emptyMap;
     }
   } else {
     ERROR("JSON CONFIG FILE DOES NOT EXIST! FILENAME:" + filename);

--- a/JPetOptions/JPetOptionsToolsTest.cpp
+++ b/JPetOptions/JPetOptionsToolsTest.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfFile)
 {
   auto inFile = "inputTestCfg.json";
   std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfFile(dataDir + inFile);
-  std::map<std::string, std::string> expected = {{"MyOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
+  std::map<std::string, std::string> expected = {{"myOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
   BOOST_REQUIRE_EQUAL(options.size(), 4);
 
   std::vector<std::string> keys_expected;

--- a/JPetOptions/JPetOptionsToolsTest.cpp
+++ b/JPetOptions/JPetOptionsToolsTest.cpp
@@ -3,6 +3,9 @@
 #include <boost/test/unit_test.hpp>
 #include "JPetOptionsTools.h"
 #include <boost/filesystem.hpp>
+#include<iostream>
+
+const std::string dataDir = "unitTestData/JPetOptionsToolsTest/";
 
 BOOST_AUTO_TEST_SUITE(FirstSuite)
 
@@ -12,16 +15,16 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromOptions )
   std::map<std::string, std::string> options = {{"TimeWindow", "10"}, {"SomeOption", "true"}, {"AnotherOption", "4.5"}};
   std::string outFile = "test_cfg.json";
   BOOST_REQUIRE(jpet_options_tools::createConfigFileFromOptions(options, outFile));
-  /// todo remove created file
+  boost::filesystem::remove("test_cfg.json");
 }
 
 
 BOOST_AUTO_TEST_CASE(createOptionsFromConfFile)
 {
   auto inFile = "inputTestCfg.json";
-  std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfFile(inFile);
+  std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfFile(dataDir + inFile);
   std::map<std::string, std::string> expected = {{"MyOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
-  BOOST_REQUIRE_EQUAL(options.size(), 4u);
+  BOOST_REQUIRE_EQUAL(options.size(), 4);
 
   std::vector<std::string> keys_expected;
   std::vector<std::string> values_expected;
@@ -39,9 +42,8 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfFile)
   std::sort(values.begin(), values.end());
   std::sort(keys_expected.begin(), keys_expected.end());
   std::sort(values_expected.begin(), values_expected.end());
-  /// I dont understand why it is not ordered correctly, anyway all elements seem to be present only reversed
-  //BOOST_REQUIRE_EQUAL_COLLECTIONS(keys.begin(), keys.end(), keys_expected.begin(), keys_expected.end());
-  //BOOST_REQUIRE_EQUAL_COLLECTIONS(values.begin(), values.end(), values_expected.begin(), values_expected.end());
+  BOOST_REQUIRE_EQUAL_COLLECTIONS(keys.begin(), keys.end(), keys_expected.begin(), keys_expected.end());
+  BOOST_REQUIRE_EQUAL_COLLECTIONS(values.begin(), values.end(), values_expected.begin(), values_expected.end());
 }
 
 BOOST_AUTO_TEST_CASE( createConfigFileFromOptionsAndReadItBack )
@@ -69,6 +71,8 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromOptionsAndReadItBack )
   std::sort(values_expected.begin(), values_expected.end());
   BOOST_REQUIRE_EQUAL_COLLECTIONS(keys.begin(), keys.end(), keys_expected.begin(), keys_expected.end());
   BOOST_REQUIRE_EQUAL_COLLECTIONS(values.begin(), values.end(), values_expected.begin(), values_expected.end());
+  boost::filesystem::remove("test_cfg2.json");
+
 }
 
 BOOST_AUTO_TEST_CASE( createOptionsFromConfFileThatDoesNotExist )
@@ -80,10 +84,18 @@ BOOST_AUTO_TEST_CASE( createOptionsFromConfFileThatDoesNotExist )
 
 BOOST_AUTO_TEST_CASE( createConfigFileFromEmptyMap )
 {
-}
+  jpet_options_tools::Options options = {};
+  std::string cfgFile = "test_cfg3.json";
+  BOOST_REQUIRE(jpet_options_tools::createConfigFileFromOptions(options, cfgFile));
+  boost::filesystem::remove("test_cfg3.json");
+} 
+
 
 BOOST_AUTO_TEST_CASE( createOptionsFromConfFileThatHasWrongFormat )
 {
+  auto inFile = "wrongInputFile.json";
+  auto options = jpet_options_tools::createOptionsFromConfFile(inFile);
+  BOOST_REQUIRE_EQUAL(options.size(),  0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetOptions/JPetOptionsToolsTest.cpp
+++ b/JPetOptions/JPetOptionsToolsTest.cpp
@@ -21,9 +21,9 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromOptions )
 
 BOOST_AUTO_TEST_CASE(createOptionsFromConfFile)
 {
-  auto inFile = "inputTestCfg.json";
-  std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfFile(dataDir + inFile);
-  std::map<std::string, std::string> expected = {{"MyOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
+  auto inFile = "unitTestData/JPetOptionsToolsTest/inputTestCfg.json";
+  std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfFile(inFile);
+  std::map<std::string, std::string> expected = {{"myOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
   BOOST_REQUIRE_EQUAL(options.size(), 4);
 
   std::vector<std::string> keys_expected;
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE( createConfigFileFromEmptyMap )
 
 BOOST_AUTO_TEST_CASE( createOptionsFromConfFileThatHasWrongFormat )
 {
-  auto inFile = "wrongInputFile.json";
+  auto inFile = "unitTestData/JPetOptionsToolsTest/wrongInputFile.json";
   auto options = jpet_options_tools::createOptionsFromConfFile(inFile);
   BOOST_REQUIRE_EQUAL(options.size(),  0);
 }

--- a/JPetOptions/JPetOptionsToolsTest.cpp
+++ b/JPetOptions/JPetOptionsToolsTest.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(createOptionsFromConfFile)
 {
   auto inFile = "inputTestCfg.json";
   std::map<std::string, std::string> options = jpet_options_tools::createOptionsFromConfFile(dataDir + inFile);
-  std::map<std::string, std::string> expected = {{"myOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
+  std::map<std::string, std::string> expected = {{"MyOption", "great"}, {"myAnotherOption", "wat"}, {"boolOption", "true"}, {"NumberOption", "12.2"}};
   BOOST_REQUIRE_EQUAL(options.size(), 4);
 
   std::vector<std::string> keys_expected;

--- a/unitTestUtils/parseXML.py
+++ b/unitTestUtils/parseXML.py
@@ -16,8 +16,10 @@ def parse():
             tree = ET.parse(infile)
             root = tree.getroot()
             if root.findall('.//FatalError'):
+                element=root.findall('.//FatalError')[0]
                 eprint("Error detected")
                 print(infile)
+                print(element.text)
                 sys.exit(1)
         except ParseError:
             eprint("The file xml isn't correct. There were some mistakes in the tests ")

--- a/unitTestUtils/parseXML.py
+++ b/unitTestUtils/parseXML.py
@@ -16,10 +16,8 @@ def parse():
             tree = ET.parse(infile)
             root = tree.getroot()
             if root.findall('.//FatalError'):
-                element=root.findall('.//FatalError')[0]
                 eprint("Error detected")
                 print(infile)
-                print(element.text)
                 sys.exit(1)
         except ParseError:
             eprint("The file xml isn't correct. There were some mistakes in the tests ")


### PR DESCRIPTION
Fix the problem with tests to JPetOptionsTools and JPetCmdParser and add add tests to JPetOptionsTools. There is also more verbose error reporting on Travis but there will be separate PR only with this change to develop.