### PR TITLE
Integration of time window and new task scheme with the examples

### DIFF
--- a/JPetCommonTools/JPetCommonTools.cpp
+++ b/JPetCommonTools/JPetCommonTools.cpp
@@ -65,3 +65,44 @@ std::vector<const char*> JPetCommonTools::createArgs(const std::string& commandL
   });
   return args_char;
 }
+
+ std::string JPetCommonTools::extractDataTypeFromFile(const std::string& filename)
+{
+  auto file = extractFileNameFromFullPath(filename);
+
+  auto pos = file.find(".");
+  if ( pos != std::string::npos ) {
+    auto suffix = file.substr(pos+1);
+    auto pos2 = suffix.find(".root");
+    if( pos2 != std::string::npos ){
+      return suffix.erase(pos2);
+    }
+  }
+  
+  return "";
+}
+
+std::string JPetCommonTools::replaceDataTypeInFile(const std::string& filename, const std::string& newType)
+{
+  auto file = extractFileNameFromFullPath(filename);
+  auto path = extractPathFromFile(filename);
+  
+  auto pos = file.find(".");
+  if ( pos != std::string::npos ) {
+    auto suffix = file.substr(pos+1);
+    auto prefix = file.erase(pos+1);
+    auto pos2 = suffix.find(".root");
+    if( pos2 != std::string::npos ){
+      auto root_extension = suffix.substr(pos2);
+      auto result = prefix.append(newType).append(root_extension);
+      if( !path.empty() ) result = path.append("/").append(result);
+      return result;
+    }
+  }
+  
+  return "";
+}
+
+
+
+

--- a/JPetCommonTools/JPetCommonTools.cpp
+++ b/JPetCommonTools/JPetCommonTools.cpp
@@ -91,6 +91,14 @@ std::string JPetCommonTools::replaceDataTypeInFile(const std::string& filename, 
   if ( pos != std::string::npos ) {
     auto suffix = file.substr(pos+1);
     auto prefix = file.erase(pos+1);
+
+    // handle HLD files as a special case
+    if( suffix == "hld" ){
+      auto result = prefix.append(newType).append(".root");
+      if( !path.empty() ) result = path.append("/").append(result);
+      return result;
+    }
+
     auto pos2 = suffix.find(".root");
     if( pos2 != std::string::npos ){
       auto root_extension = suffix.substr(pos2);

--- a/JPetCommonTools/JPetCommonTools.h
+++ b/JPetCommonTools/JPetCommonTools.h
@@ -125,6 +125,9 @@ public:
     return boost::filesystem::path( fileWithPath ).filename().string();
   }
 
+  static std::string extractDataTypeFromFile(const std::string& filename);
+  static std::string replaceDataTypeInFile(const std::string& filename, const std::string& newType);
+  
   inline static std::string appendSlashToPathIfAbsent(const std::string& path)
   {
     if (!path.empty() && path.back() != '/') return path + '/';

--- a/JPetCommonTools/JPetCommonToolsTest.cpp
+++ b/JPetCommonTools/JPetCommonToolsTest.cpp
@@ -194,4 +194,25 @@ BOOST_AUTO_TEST_CASE(createArgsTest4)
   }
 }
 
+BOOST_AUTO_TEST_CASE(fileTypeSuffixOperations)
+{
+  std::string path = "../../file.tslot.raw.root";
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path), "tslot.raw");
+  std::string path2 = JPetCommonTools::replaceDataTypeInFile(path, "phys.sig.cal");
+  BOOST_REQUIRE_EQUAL(path2, "../../file.phys.sig.cal.root");
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path2), "phys.sig.cal");
+  
+  path = "test.hld.root";
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path), "hld");
+  path2 = JPetCommonTools::replaceDataTypeInFile(path, "foo.bar");
+  BOOST_REQUIRE_EQUAL(path2, "test.foo.bar.root");
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path2), "foo.bar");
+
+  path = "/home//whoever/somefile.a.b.c.d.root";
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path), "a.b.c.d");
+  path2 = JPetCommonTools::replaceDataTypeInFile(path, "hits");
+  BOOST_REQUIRE_EQUAL(path2, "/home//whoever/somefile.hits.root");
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path2), "hits");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetCommonTools/JPetCommonToolsTest.cpp
+++ b/JPetCommonTools/JPetCommonToolsTest.cpp
@@ -213,6 +213,11 @@ BOOST_AUTO_TEST_CASE(fileTypeSuffixOperations)
   path2 = JPetCommonTools::replaceDataTypeInFile(path, "hits");
   BOOST_REQUIRE_EQUAL(path2, "/home//whoever/somefile.hits.root");
   BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path2), "hits");
+
+  path = "/some/path/foo.hld";
+  path2 = JPetCommonTools::replaceDataTypeInFile(path, "tslot.raw");
+  BOOST_REQUIRE_EQUAL(path2, "/some/path/foo.tslot.raw.root");
+  BOOST_REQUIRE_EQUAL(JPetCommonTools::extractDataTypeFromFile(path2), "tslot.raw");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/JPetManager/JPetManager.cpp
+++ b/JPetManager/JPetManager.cpp
@@ -151,7 +151,7 @@ void JPetManager::useTask(const char* name, const char* inputFileType, const cha
     // wrap the JPetUserTask-based task in a JPetTaskIO
     fTaskGeneratorChain->push_back( [name, inputFileType, outputFileType, userTaskGen]() {
 	JPetTaskIO * task = new JPetTaskIO(name, inputFileType, outputFileType);
-	task->setSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
+	task->addSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
 	return task;
       });
   }else{

--- a/JPetManager/JPetManager.cpp
+++ b/JPetManager/JPetManager.cpp
@@ -143,10 +143,21 @@ JPetManager::~JPetManager()
   JPetDBParamGetter::clearParamCache();
 }
 
-void JPetManager::registerTask(const TaskGenerator& taskGen)
-{
+
+void JPetManager::useTask(const char* name, const char* inputFileType, const char* outputFileType){
   assert(fTaskGeneratorChain);
-  fTaskGeneratorChain->push_back(taskGen);
+  if( fTasksDictionary.count(name) > 0 ){
+    TaskGenerator userTaskGen = fTasksDictionary.at(name);
+    // wrap the JPetUserTask-based task in a JPetTaskIO
+    fTaskGeneratorChain->push_back( [name, inputFileType, outputFileType, userTaskGen]() {
+	JPetTaskIO * task = new JPetTaskIO(name, inputFileType, outputFileType);
+	task->setSubTask(std::unique_ptr<JPetTaskInterface>(userTaskGen()));
+	return task;
+      });
+  }else{
+    ERROR(Form("The requested task %s is unknown", name));
+    exit(1);
+  }
 }
 
 JPetManager::Options JPetManager::getOptions() const

--- a/JPetManager/JPetManager.cpp
+++ b/JPetManager/JPetManager.cpp
@@ -127,7 +127,7 @@ bool JPetManager::parseCmdLine(int argc, const char** argv)
     if (fTaskGeneratorChain) {
       numberOfRegisteredTasks = fTaskGeneratorChain->size();
     }
-    fOptions  = optionsGenerator.generateOptionsForTasks(allValidatedOptions, numberOfRegisteredTasks);
+    fOptions = optionsGenerator.generateOptionsForTasks(allValidatedOptions, numberOfRegisteredTasks);
   } catch (std::exception& e) {
     ERROR(e.what());
     return false;
@@ -181,13 +181,10 @@ bool JPetManager::initDBConnection(const char* configFilePath)
   bool isDBrequired = false;
 
   if (fOptions.size() > 0) { // If at least one input file to process.
-    auto optsVect = fOptions.begin()->second;
-    if (optsVect.size() > 0) {
-      auto opt = optsVect.front();
-      if (getRunNumber(opt) >= 0) { // if run number is not default -1
-        if (!isLocalDB(opt)) { // unless local DB file was provided
-          isDBrequired = true;
-        }
+    auto opts = fOptions.begin()->second;
+    if (getRunNumber(opts) >= 0) { // if run number is not default -1
+      if (!isLocalDB(opts)) { // unless local DB file was provided
+	isDBrequired = true;
       }
     }
   }

--- a/JPetManager/JPetManager.h
+++ b/JPetManager/JPetManager.h
@@ -33,7 +33,7 @@
 class JPetManager
 {
 public:
-  using Options = std::map<std::string, std::vector<jpet_options_tools::OptsStrAny>>;
+  using Options = std::map<std::string, jpet_options_tools::OptsStrAny>;
   using TaskGenerator = std::function< JPetTaskInterface* () >;
   using TaskGeneratorChain = std::vector<TaskGenerator>;
 

--- a/JPetManager/JPetManager.h
+++ b/JPetManager/JPetManager.h
@@ -20,6 +20,7 @@
 #include "../JPetTaskChainExecutor/JPetTaskChainExecutor.h"
 #include "../JPetOptionsTools/JPetOptionsTools.h"
 #include <memory>
+#include <map>
 
 /**
  * @brief Main manager of the analysis performed with the J-PET Framework.
@@ -40,7 +41,12 @@ public:
   ~JPetManager();
 
   bool run(int argc, const char** argv);
-  void registerTask(const TaskGenerator& taskGen);
+  
+  template<typename T> void registerTask(const char * name){
+    fTasksDictionary[name] = [name]() {
+      return new T(name);
+    };
+  }
   /// Function parses command line arguments and generates options for tasks.
   /// The fOptions is filled with the generated options.
   bool parseCmdLine(int argc, const char** argv);
@@ -48,7 +54,9 @@ public:
   bool areThreadsEnabled() const;
   void setThreadsEnabled(bool enable);
   bool initDBConnection(const char* configFilePath = "../DBConfig/configDB.cfg");
-
+  // @todo: replace the need to call this method with task list passed as an option  
+  void useTask(const char * name, const char * inputFileType="", const char * outputFileType="");
+  
 private:
   JPetManager(const JPetManager&);
   void operator=(const JPetManager&);
@@ -58,5 +66,13 @@ private:
   Options fOptions;
   TaskGeneratorChain* fTaskGeneratorChain = nullptr; /// fTaskGeneratorChain is a sequences of registered computing tasks.
   bool fThreadsEnabled = false;
+  std::map<const char *, TaskGenerator> fTasksDictionary;
 };
 #endif /*  !JPETMANAGER_H */
+
+
+
+
+
+
+

--- a/JPetOptionsGenerator/JPetOptionsGenerator.cpp
+++ b/JPetOptionsGenerator/JPetOptionsGenerator.cpp
@@ -82,12 +82,7 @@ JPetOptionsGenerator::OptsForFiles JPetOptionsGenerator::generateOptionsForTasks
   }
   assert(nbOfRegisteredTasks > 0);
 
-  /// Finally, multiple the options for every task.
-  for (const auto& el : optionsPerFile) {
-    std::vector<OptsStrAny>  currOpts(nbOfRegisteredTasks, el.second);
-    optsForAllFiles[el.first] = currOpts;
-  }
-  return optsForAllFiles;
+  return optionsPerFile;
 }
 
 JPetOptionsGenerator::OptsStrAny JPetOptionsGenerator::generateAndValidateOptions(const po::variables_map& cmdLineArgs)

--- a/JPetOptionsGenerator/JPetOptionsGenerator.h
+++ b/JPetOptionsGenerator/JPetOptionsGenerator.h
@@ -34,7 +34,7 @@ class JPetOptionsGenerator
 {
 public:
   using OptsStrAny = std::map<std::string, boost::any>;
-  using OptsForTasks =  std::vector<OptsStrAny>;
+  using OptsForTasks = OptsStrAny;
   using OptsForFiles = std::map<std::string, OptsForTasks>;
   using TransformersMap = std::map<std::string, std::vector<jpet_options_tools::Transformer> >;
 

--- a/JPetOptionsGenerator/JPetOptionsGeneratorTest.cpp
+++ b/JPetOptionsGenerator/JPetOptionsGeneratorTest.cpp
@@ -70,9 +70,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_oneFileOneTask)
   BOOST_REQUIRE_EQUAL(result.size(), 1); //one file
   auto it = result.begin();
   BOOST_REQUIRE_EQUAL(it->first, "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(it->second.size(), 1u); // one task
-  auto itTaskOpts = it->second.begin(); //get options for this one task
-  auto opts = *itTaskOpts;
+  auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts),  231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile.root");
   BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
@@ -104,9 +102,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_TwoFilesOneTasks)
 
   auto it = result.begin(); //first file
   BOOST_REQUIRE_EQUAL(it->first, "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(it->second.size(), 1u); // one tasks
-  auto itTaskOpts = it->second.begin();
-  auto opts = *itTaskOpts; //get option for first task
+  auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts),  231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile.root");
   BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
@@ -118,9 +114,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_TwoFilesOneTasks)
 
   it++; //second file
   BOOST_REQUIRE_EQUAL(it->first, "unitTestData/JPetOptionsGeneratorTest/infile2.root");
-  BOOST_REQUIRE_EQUAL(it->second.size(), 1u);
-  itTaskOpts = it->second.begin();
-  opts = *itTaskOpts; //get option for first task of second file
+  opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts),  231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile2.root");
   BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
@@ -143,9 +137,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_oneFileTwoTasksWithOutput)
   BOOST_REQUIRE_EQUAL(result.size(), 1); //one file
   auto it = result.begin();
   BOOST_REQUIRE_EQUAL(it->first, "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(it->second.size(), 2u); // two tasks
-  auto itTaskOpts = it->second.begin();
-  auto opts = *itTaskOpts; //get option for first task
+  auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts),  231);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetOptionsGeneratorTest/infile.root");
   BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts), FileTypeChecker::kRoot);
@@ -155,19 +147,6 @@ BOOST_AUTO_TEST_CASE(generateOptions_oneFileTwoTasksWithOutput)
   BOOST_REQUIRE(!isProgressBar(opts));
   BOOST_REQUIRE(!isLocalDB(opts) );
   BOOST_REQUIRE(!isLocalDBCreate(opts));
-  itTaskOpts++;
-  opts["resetEventRange_bool"] = true; ///to reset event number
-  auto opts2 = *itTaskOpts; //get option for second task
-  opts2 = generateOptionsForTask(opts2, opts);
-  BOOST_REQUIRE_EQUAL(getRunNumber(opts2),  231);
-  BOOST_REQUIRE_EQUAL(getInputFile(opts2), "unitTestData/JPetCmdParserTest/infile.root");
-  BOOST_REQUIRE_EQUAL(FileTypeChecker::getInputFileType(opts2), FileTypeChecker::kRoot);
-  BOOST_REQUIRE_EQUAL(getOutputPath(opts2), "unitTestData/JPetCmdParserTest/");
-  BOOST_REQUIRE_EQUAL(getFirstEvent(opts2),  -1); /// second task has event numbers reset
-  BOOST_REQUIRE_EQUAL(getLastEvent(opts2),   -1);
-  BOOST_REQUIRE(!isProgressBar(opts2));
-  BOOST_REQUIRE(!isLocalDB(opts2) );
-  BOOST_REQUIRE(!isLocalDBCreate(opts2));
 }
 
 BOOST_AUTO_TEST_CASE(generateOptions_TestWithUserOptions)
@@ -182,9 +161,7 @@ BOOST_AUTO_TEST_CASE(generateOptions_TestWithUserOptions)
   BOOST_REQUIRE_EQUAL(result.size(), 1); //one file
   auto it = result.begin();
   BOOST_REQUIRE_EQUAL(it->first, "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(it->second.size(), 1u); // one task
-  auto itTaskOpts = it->second.begin();
-  auto opts = *itTaskOpts; //get option for first task
+  auto opts = it->second;
 
   BOOST_REQUIRE(!opts.empty());
   BOOST_REQUIRE_EQUAL(getRunNumber(opts),  231);
@@ -220,12 +197,9 @@ BOOST_AUTO_TEST_CASE(ScopeOptions)
   auto result = gener.generateOptionsForTasks(opt, 1);
   BOOST_REQUIRE(!result.empty());
   BOOST_REQUIRE_EQUAL(result.size(), 1u); //one file
-
   auto it = result.begin();
   BOOST_REQUIRE_EQUAL(it->first, "unitTestData/JPetScopeLoaderTest/test_file_test_0");  ///fake input file
-  BOOST_REQUIRE_EQUAL(it->second.size(), 1u); // one tasks
-  auto itTaskOpts = it->second.begin();
-  auto opts = *itTaskOpts; //get option for first task
+  auto opts = it->second;
   BOOST_REQUIRE_EQUAL(getRunNumber(opts),  1);
   BOOST_REQUIRE_EQUAL(getInputFile(opts), "unitTestData/JPetScopeLoaderTest/test_file_test_0"); /// fake input file
   BOOST_REQUIRE_EQUAL(getScopeConfigFile(opts), "unitTestData/JPetScopeLoaderTest/test_file.json");

--- a/JPetOptionsGenerator/JPetOptionsGeneratorTest.cpp
+++ b/JPetOptionsGenerator/JPetOptionsGeneratorTest.cpp
@@ -87,7 +87,6 @@ BOOST_AUTO_TEST_CASE(generateOptions_oneFileTwoTasks)
   BOOST_REQUIRE(!result.empty());
   BOOST_REQUIRE_EQUAL(result.size(), 1); //one file
   BOOST_REQUIRE_EQUAL(result.begin()->first, "unitTestData/JPetOptionsGeneratorTest/infile.root");
-  BOOST_REQUIRE_EQUAL(result.begin()->second.size(), 2u); // two tasks
 }
 
 BOOST_AUTO_TEST_CASE(generateOptions_TwoFilesOneTasks)

--- a/JPetOptionsGenerator/JPetOptionsGeneratorTools.cpp
+++ b/JPetOptionsGenerator/JPetOptionsGeneratorTools.cpp
@@ -150,6 +150,9 @@ OptsStrAny generateOptionsForTask(const OptsStrAny& inOptions, const OptsStrAny&
   if (isOptionSet(controlSettings, "outputFileType_std::string")) {
     newOpts["inputFileType_std::string"] = getOptionAsString(controlSettings, "outputFileType_std::string");
   }
+  if (isOptionSet(controlSettings, "outputFile_std::string")) {
+    newOpts["inputFile_std::string"] = getOptionAsString(controlSettings, "outputFile_std::string");
+  }
   if (isOptionSet(controlSettings, "outputPath_std::string")) {
     auto outPath  = std::string(getOutputPath(controlSettings));
     if (!outPath.empty()) {
@@ -168,6 +171,11 @@ void setOutputFileType(OptsStrAny& options, const std::string& fileType)
 {
   options["outputFileType_std::string"] = fileType;
 }
+
+void setOutputFile(OptsStrAny& options, const std::string& file)
+{
+  options["outputFile_std::string"] = file;
+}  
 
 void setOutputPath(OptsStrAny& options, const std::string& path)
 {

--- a/JPetOptionsGenerator/JPetOptionsGeneratorTools.h
+++ b/JPetOptionsGenerator/JPetOptionsGeneratorTools.h
@@ -60,6 +60,7 @@ OptsStrAny resetEventRange(const OptsStrAny& srcOpts);
 void setResetEventRangeOption(OptsStrAny& options, bool isReset);
 /// key outputFileType_std::string
 void setOutputFileType(OptsStrAny& options, const std::string& fileType);
+void setOutputFile(OptsStrAny& options, const std::string& file);
 /// key outputPath_std::string
 void setOutputPath(OptsStrAny& options, const std::string& path);
 

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -61,26 +61,21 @@ bool JPetTaskChainExecutor::process()
   JPetDataInterface nullDataObject;
   JPetParams controlParams; /// Parameters used to control the input file type and event range.
 
-  assert(fTasks.size() == fParams.size());
-  auto currParamsIt = fParams.begin();
-
   /// We iterate over both tasks and parameters
   for (auto currentTaskIt = fTasks.begin(); currentTaskIt != fTasks.end(); currentTaskIt++) {
 
     auto currentTask  =  *currentTaskIt;
     auto taskName = currentTask->getName();
 
-    assert(currParamsIt != fParams.end());
-    auto currParams = *currParamsIt;
+    auto & currParams = fParams;
     /// We generate input parameters based on the current parameter set and the controlParams produced by
     /// the previous task.
-    auto inputParams = JPetTaskChainExecutorUtils::generateParams(currParams, controlParams);
+    currParams = JPetTaskChainExecutorUtils::generateParams(currParams, controlParams);
     jpet_options_tools::printOptionsToLog(currParams.getOptions(), std::string("Options for ") + taskName);
-    currParamsIt++;
-
+    
     timer.startMeasurement();
     INFO(Form("Starting task: %s", taskName.c_str()));
-    if (!currentTask->init(inputParams)) {
+    if (!currentTask->init(currParams)) {
       ERROR("In task initialization");
       return false;
     }

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.cpp
@@ -21,15 +21,15 @@
 
 #include "JPetTaskChainExecutorUtils.h"
 #include "../JPetLoggerInclude.h"
+#include "../JPetOptionsGenerator/JPetOptionsGeneratorTools.h"
 
-JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, const OptionsPerFile& opts):
+JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFileId, const jpet_options_tools::OptsStrAny& opts):
   fInputSeqId(processedFileId),
   ftaskGeneratorChain(taskGeneratorChain)
 {
-  assert(taskGeneratorChain->size() == opts.size());
   /// ParamManager is generated and added to fParams
   fParams = JPetTaskChainExecutorUtils::generateParams(opts);
-  assert(fParams.front().getParamManager());
+  assert(fParams.getParamManager());
   if (taskGeneratorChain) {
     for (auto taskGenerator : *ftaskGeneratorChain) {
       auto task = taskGenerator();
@@ -41,14 +41,9 @@ JPetTaskChainExecutor::JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorCh
 }
 
 
-bool JPetTaskChainExecutor::preprocessing(const std::vector<JPetParams>& params)
+bool JPetTaskChainExecutor::preprocessing(const JPetParams& params)
 {
-  if (params.empty()) {
-    ERROR("No parameters provided!");
-    return false;
-  } else {
-    return JPetTaskChainExecutorUtils::process(params.front());
-  }
+  return JPetTaskChainExecutorUtils::process(params);
 }
 
 bool JPetTaskChainExecutor::process()

--- a/JPetTaskChainExecutor/JPetTaskChainExecutor.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutor.h
@@ -26,7 +26,6 @@
 
 using TaskGenerator = std::function< JPetTaskInterface* () >;
 using TaskGeneratorChain = std::vector<TaskGenerator>;
-using OptionsPerFile = std::vector<jpet_options_tools::OptsStrAny>;
 
 /**
  * JPetTaskChainExecutor generates the previously registered chain of tasks.
@@ -35,18 +34,18 @@ using OptionsPerFile = std::vector<jpet_options_tools::OptsStrAny>;
 class JPetTaskChainExecutor
 {
 public :
-  JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFile, const OptionsPerFile& opts);
+  JPetTaskChainExecutor(TaskGeneratorChain* taskGeneratorChain, int processedFile, const jpet_options_tools::OptsStrAny&);
   TThread* run();
   virtual ~JPetTaskChainExecutor();
   bool process(); /// Method to be called directly only in case of non-thread running;
 private:
   static void* processProxy(void*);
-  bool preprocessing(const std::vector<JPetParams>& params);
+  bool preprocessing(const JPetParams& params);
 
   int fInputSeqId = -1;
   std::list<JPetTaskInterface*> fTasks;
   TaskGeneratorChain* ftaskGeneratorChain = nullptr;
-  std::vector<JPetParams> fParams;
+  JPetParams fParams;
 };
 
 

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorTest.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorTest.cpp
@@ -49,35 +49,30 @@ BOOST_AUTO_TEST_SUITE(JPetTaskChainExecutorTestSuite)
 
 BOOST_AUTO_TEST_CASE(test1)
 {
-  std::vector<jpet_options_tools::OptsStrAny> opts;
   auto opt = jpet_options_generator_tools::getDefaultOptions();
   opt["inputFile_std::string"] = std::string("unitTestData/JPetTaskChainExecutorTest/dabc_17025151847.unk.evt.root");
   opt["inputFileType_std::string"] = std::string("root");
   opt["outputFile_std::string"] = std::string("JPetTaskChainExecutorTest1.root");
-  opts.push_back(opt);
   auto taskGenerator1 = []() {
     return new JPetTaskIO("test1");
   };
   TaskGeneratorChain* chain =  new TaskGeneratorChain;
   chain->push_back(taskGenerator1);
 
-  JPetTaskChainExecutor taskExecutor(chain, 1, opts);
+  JPetTaskChainExecutor taskExecutor(chain, 1, opt);
   BOOST_REQUIRE(!taskExecutor.process()); //TaskIO with no subtask is no allowed
   delete chain;
 }
 
 BOOST_AUTO_TEST_CASE(test2)
 {
-  std::vector<jpet_options_tools::OptsStrAny> opts;
   auto opt = jpet_options_generator_tools::getDefaultOptions();
   opt["firstEvent_int"] = 0;
   opt["lastEvent_int"] = 10;
   opt["inputFile_std::string"] = std::string("unitTestData/JPetTaskChainExecutorTest/dabc_17025151847.unk.evt.root");
   opt["inputFileType_std::string"] = std::string("root");
   opt["outputFile_std::string"] = std::string("JPetTaskChainExecutorTest2Chain1.root");
-  opts.push_back(opt);
   opt["outputFile_std::string"] = std::string("JPetTaskChainExecutorTest2Chain2.root");
-  opts.push_back(opt);
 
   auto taskGenerator1 = []() {
     auto taskIO =  new JPetTaskIO("TaskA");
@@ -95,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test2)
   chain->push_back(taskGenerator2);
 
   BOOST_REQUIRE_EQUAL(chain->size(), 2u);
-  JPetTaskChainExecutor taskExecutor(chain, 1, opts);
+  JPetTaskChainExecutor taskExecutor(chain, 1, opt);
   BOOST_REQUIRE(taskExecutor.process());
   delete chain;
 }

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.cpp
@@ -49,16 +49,10 @@ bool JPetTaskChainExecutorUtils::process(const JPetParams& params)
 }
 
 ///@todo this function should be moved to some other class
-std::vector<JPetParams> JPetTaskChainExecutorUtils::generateParams(const OptionsPerFile& opts)
+JPetParams JPetTaskChainExecutorUtils::generateParams(const jpet_options_tools::OptsStrAny& opts)
 {
-  std::vector<JPetParams> params;
-  std::shared_ptr<JPetParamManager> paramManager2 = JPetTaskChainExecutorUtils::generateParamManager(opts.front());
-
-  params.reserve(opts.size());
-  for (const auto& opt : opts) {
-    params.push_back(JPetParams(opt, paramManager2));
-  }
-  return params;
+  std::shared_ptr<JPetParamManager> paramManager2 = JPetTaskChainExecutorUtils::generateParamManager(opts);
+  return JPetParams(opts, paramManager2);
 }
 
 ///@todo this function should be moved to some other class

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtils.h
@@ -27,10 +27,9 @@
 class JPetTaskChainExecutorUtils
 {
 public:
-  using OptionsPerFile = std::vector<jpet_options_tools::OptsStrAny>;
   /// process() method depends on the options can: 1.saves paramBank locally in ASCII format
   static bool process(const JPetParams& params);
-  static std::vector<JPetParams> generateParams(const OptionsPerFile& opts);
+  static JPetParams generateParams(const jpet_options_tools::OptsStrAny& opts);
   static std::shared_ptr<JPetParamManager> generateParamManager(const std::map<std::string, boost::any>& options);
   static JPetParams generateParams(const JPetParams& inParams, const JPetParams& controlParams);
 };

--- a/JPetTaskChainExecutor/JPetTaskChainExecutorUtilsTest.cpp
+++ b/JPetTaskChainExecutor/JPetTaskChainExecutorUtilsTest.cpp
@@ -55,28 +55,10 @@ BOOST_AUTO_TEST_CASE(generateParamManagerForScopeCase)
 
 BOOST_AUTO_TEST_CASE(generateParams)
 {
-  std::map<std::string, boost::any> optPerFile;
-  std::vector<std::map<std::string, boost::any>> opts = {optPerFile};
+  std::map<std::string, boost::any> opts;
   auto params = JPetTaskChainExecutorUtils::generateParams(opts);
-  BOOST_REQUIRE_EQUAL(params.size(), 1u);
-  auto firstParam = params.front();
-  BOOST_REQUIRE(firstParam.getOptions().empty());
-  BOOST_REQUIRE(firstParam.getParamManager());
-}
-
-BOOST_AUTO_TEST_CASE(generateParams2)
-{
-  std::map<std::string, boost::any> optPerFile;
-  std::vector<std::map<std::string, boost::any>> opts = {optPerFile, optPerFile};
-  auto params = JPetTaskChainExecutorUtils::generateParams(opts);
-  BOOST_REQUIRE_EQUAL(params.size(), 2u);
-  auto first = params.front();
-  BOOST_REQUIRE(first.getOptions().empty());
-  BOOST_REQUIRE(first.getParamManager());
-  auto second = params.back();
-  BOOST_REQUIRE(second.getOptions().empty());
-  BOOST_REQUIRE(second.getParamManager());
-  BOOST_REQUIRE_EQUAL(first.getParamManager(), second.getParamManager());
+  BOOST_REQUIRE(params.getOptions().empty());
+  BOOST_REQUIRE(params.getParamManager());
 }
 
 BOOST_AUTO_TEST_CASE(process)

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -239,7 +239,6 @@ bool JPetTaskIO::createInputObjects(const char* inputFilename)
     } else {
       auto paramManager = fParams.getParamManager();
       assert(paramManager);
-      paramManager->clearParameters();
       if(!paramManager->readParametersFromFile(dynamic_cast<JPetReader*> (fReader))){
 	ERROR("Failed to read paramBank from input file.");
 	return false;

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -22,6 +22,7 @@
 #include "../JPetUserTask/JPetUserTask.h"
 #include "../JPetCommonTools/JPetCommonTools.h"
 #include "../JPetData/JPetData.h"
+#include "../JPetOptionsGenerator/JPetOptionsGeneratorTools.h"
 
 #include "../JPetLoggerInclude.h"
 #include "../version.h"
@@ -33,7 +34,9 @@ JPetTaskIO::JPetTaskIO(const char* name,
 		       const char* out_file_type):
   JPetTask(name),
   fInFileType(in_file_type),
-  fOutFileType(out_file_type)
+  fOutFileType(out_file_type),
+  fOutFileFullPath(""),
+  fResetOutputPath(false)
 {
 }
 
@@ -50,14 +53,31 @@ bool JPetTaskIO::init(const JPetParamsInterface& paramsI)
   auto params = dynamic_cast<const JPetParams&>(paramsI);
   setOptions(params);
   auto opts = fParams.getOptions();
-  std::string inputFilename(generateProperNameFile(getInputFile(opts), fInFileType));
-  std::string outputPath(getOutputPath(opts));
-  auto outputFilename = outputPath + std::string(generateProperNameFile(getOutputFile(opts), fOutFileType));
+
+  // handle input file path
+  std::string inputFilename = getInputFile(opts);
+  if( JPetCommonTools::extractDataTypeFromFile(inputFilename) != fInFileType ){
+    ERROR(Form("Input file type %s does not match the one provided by the previous module (%s).",
+	       fInFileType.c_str(), JPetCommonTools::extractDataTypeFromFile(inputFilename).c_str()));
+    return false;
+  }
+  inputFilename = JPetCommonTools::replaceDataTypeInFile(inputFilename, fInFileType);
+  // handle output file path
+  fOutFileFullPath = inputFilename;
+  if(isOptionSet(opts, "outputPath_std::string")){
+    std::string outputPath(getOutputPath(opts));
+    if(!outputPath.empty()){
+      fOutFileFullPath = outputPath + JPetCommonTools::extractFileNameFromFullPath(getInputFile(opts));
+      fResetOutputPath = true;
+    }
+  }
+  fOutFileFullPath = JPetCommonTools::replaceDataTypeInFile(fOutFileFullPath, fOutFileType);
+  
   if (!createInputObjects(inputFilename.c_str())) {
     ERROR("createInputObjects");
     return false;
   }
-  if (!createOutputObjects(outputFilename.c_str())) {
+  if (!createOutputObjects(fOutFileFullPath.c_str())) {
     ERROR("createOutputObjects");
     return false;
   }
@@ -120,8 +140,27 @@ bool JPetTaskIO::run(const JPetDataInterface&)
 }
 
 
-bool JPetTaskIO::terminate(JPetParamsInterface&)
+bool JPetTaskIO::terminate(JPetParamsInterface& output_params)
 {
+  auto & params = dynamic_cast<JPetParams&>(output_params);
+  OptsStrAny new_opts;
+  if(FileTypeChecker::getInputFileType(fParams.getOptions()) == FileTypeChecker::kHldRoot){
+    jpet_options_generator_tools::setOutputFileType(new_opts, "root");
+  }
+
+  if( jpet_options_tools::getOptionAsInt(fParams.getOptions(), "firstEvent_int") != -1 &&
+      jpet_options_tools::getOptionAsInt(fParams.getOptions(), "lastEvent_int") != -1 ){
+    jpet_options_generator_tools::setResetEventRangeOption(new_opts, true);
+  }
+  
+  if(fResetOutputPath){
+    jpet_options_generator_tools::setOutputPath(new_opts, "");
+  }
+
+  jpet_options_generator_tools::setOutputFile(new_opts, fOutFileFullPath);
+  
+  params = JPetParams(new_opts, params.getParamManagerAsShared());
+  
   if (!fReader) {
     ERROR("fReader set to null");
     return false;
@@ -200,11 +239,14 @@ bool JPetTaskIO::createInputObjects(const char* inputFilename)
     } else {
       auto paramManager = fParams.getParamManager();
       assert(paramManager);
-      paramManager->readParametersFromFile(dynamic_cast<JPetReader*> (fReader));
+      paramManager->clearParameters();
+      if(!paramManager->readParametersFromFile(dynamic_cast<JPetReader*> (fReader))){
+	ERROR("Failed to read paramBank from input file.");
+	return false;
+      }
+      assert(paramManager->getParamBank().getPMsSize() > 0);
       // read the header from the previous analysis stage
-      //
       fHeader = dynamic_cast<JPetReader*>(fReader)->getHeaderClone();
-      //fParamManager.readParametersFromFile( fReader );
     }
     // create an object for storing histograms and counters during processing
     // make_unique is not available in c++11 :(
@@ -315,27 +357,5 @@ bool JPetTaskIO::setUserLimits(const OptsStrAny& opts, const long long kTotEvent
   return true;
 }
 
-std::string JPetTaskIO::generateProperNameFile(const std::string& srcFilename, const std::string& fileType) const
-{
-  auto baseFileName = getBaseFilePath(srcFilename);
-  if (!fileType.empty()) {
-    baseFileName = baseFileName + "." + fileType;
-  }
-  return baseFileName + ".root";
-}
 
-std::string JPetTaskIO::getBaseFilePath(const std::string& srcName) const
-{
-  boost::filesystem::path p(srcName);
-  // the file name and path are treated separately not to strip dots from the path
-  std::string name = p.filename().native();
-  boost::filesystem::path dir = p.parent_path().native();
-  //strip the "extension" starting from the first dot in the file name
-  auto pos = name.find(".");
-  if ( pos != std::string::npos ) {
-    name.erase( pos );
-  }
-  boost::filesystem::path bare_name(name);
 
-  return (dir / bare_name).native();
-}

--- a/JPetTaskIO/JPetTaskIO.cpp
+++ b/JPetTaskIO/JPetTaskIO.cpp
@@ -28,7 +28,12 @@
 
 using namespace jpet_options_tools;
 
-JPetTaskIO::JPetTaskIO(const char* name): JPetTask(name)
+JPetTaskIO::JPetTaskIO(const char* name,
+		       const char* in_file_type,
+		       const char* out_file_type):
+  JPetTask(name),
+  fInFileType(in_file_type),
+  fOutFileType(out_file_type)
 {
 }
 
@@ -45,9 +50,9 @@ bool JPetTaskIO::init(const JPetParamsInterface& paramsI)
   auto params = dynamic_cast<const JPetParams&>(paramsI);
   setOptions(params);
   auto opts = fParams.getOptions();
-  std::string inputFilename(getInputFile(opts));
+  std::string inputFilename(generateProperNameFile(getInputFile(opts), fInFileType));
   std::string outputPath(getOutputPath(opts));
-  auto outputFilename = outputPath + std::string(getOutputFile(opts));
+  auto outputFilename = outputPath + std::string(generateProperNameFile(getOutputFile(opts), fOutFileType));
   if (!createInputObjects(inputFilename.c_str())) {
     ERROR("createInputObjects");
     return false;
@@ -308,4 +313,29 @@ bool JPetTaskIO::setUserLimits(const OptsStrAny& opts, const long long kTotEvent
   assert(last >= 0);
   assert(first <= last);
   return true;
+}
+
+std::string JPetTaskIO::generateProperNameFile(const std::string& srcFilename, const std::string& fileType) const
+{
+  auto baseFileName = getBaseFilePath(srcFilename);
+  if (!fileType.empty()) {
+    baseFileName = baseFileName + "." + fileType;
+  }
+  return baseFileName + ".root";
+}
+
+std::string JPetTaskIO::getBaseFilePath(const std::string& srcName) const
+{
+  boost::filesystem::path p(srcName);
+  // the file name and path are treated separately not to strip dots from the path
+  std::string name = p.filename().native();
+  boost::filesystem::path dir = p.parent_path().native();
+  //strip the "extension" starting from the first dot in the file name
+  auto pos = name.find(".");
+  if ( pos != std::string::npos ) {
+    name.erase( pos );
+  }
+  boost::filesystem::path bare_name(name);
+
+  return (dir / bare_name).native();
 }

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -39,7 +39,7 @@ class JPetStatistics;
 class JPetTaskIO: public JPetTask
 {
 public:
-  JPetTaskIO(const char* name = "");
+  JPetTaskIO(const char* name = "", const char* in_file_type="", const char* out_file_type="");
   virtual bool init(const JPetParamsInterface& inOptions) override;
   virtual bool run(const JPetDataInterface& inData) override;
   virtual bool terminate(JPetParamsInterface& outOptions) override;
@@ -62,6 +62,27 @@ protected:
   const JPetParamBank& getParamBank();
   JPetParamManager& getParamManager();
 
+  std::string generateProperNameFile(const std::string& srcFilename, const std::string& fileType) const;
+
+  /**
+   * @brief Strips the framework file "extension" from full file path
+   *
+   * The "extension" can be composed of multiple parts, dot-separated.
+   * The extension carries information not only about file type but also
+   * about types of the objects within the ROOT file.
+   * Everything following the first dot in the file name (but not in the file
+   * path) is treated as an extension.
+   *
+   * Example:
+   * ./data/somefile.phys.sig.root
+   * the extension is "phys.sig.root"
+   *
+   */
+  std::string getBaseFilePath(const std::string& srcName) const;
+
+  std::string fInFileType;
+  std::string fOutFileType;
+  
   int fEventNb = -1;
   JPetParams fParams;
   JPetWriter* fWriter = 0;

--- a/JPetTaskIO/JPetTaskIO.h
+++ b/JPetTaskIO/JPetTaskIO.h
@@ -62,26 +62,10 @@ protected:
   const JPetParamBank& getParamBank();
   JPetParamManager& getParamManager();
 
-  std::string generateProperNameFile(const std::string& srcFilename, const std::string& fileType) const;
-
-  /**
-   * @brief Strips the framework file "extension" from full file path
-   *
-   * The "extension" can be composed of multiple parts, dot-separated.
-   * The extension carries information not only about file type but also
-   * about types of the objects within the ROOT file.
-   * Everything following the first dot in the file name (but not in the file
-   * path) is treated as an extension.
-   *
-   * Example:
-   * ./data/somefile.phys.sig.root
-   * the extension is "phys.sig.root"
-   *
-   */
-  std::string getBaseFilePath(const std::string& srcName) const;
-
   std::string fInFileType;
   std::string fOutFileType;
+  std::string fOutFileFullPath;
+  bool fResetOutputPath;
   
   int fEventNb = -1;
   JPetParams fParams;

--- a/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
+++ b/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
@@ -19,6 +19,7 @@
 #include "../JPetOptionsGenerator/JPetOptionsGeneratorTools.h"
 #include "../JPetCommonTools/JPetCommonTools.h"
 #include "../JPetUnpacker/JPetUnpacker.h"
+#include "../JPetOptionsTools/JPetOptionsTools.h"
 
 JPetUnzipAndUnpackTask::JPetUnzipAndUnpackTask(const char* name): JPetTask(name), fUnpackHappened(false)
 {
@@ -66,13 +67,28 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
 
 bool JPetUnzipAndUnpackTask::terminate(JPetParamsInterface& output_params)
 {
+  using namespace jpet_options_tools;
+  
   if(fUnpackHappened){
     auto & params = dynamic_cast<JPetParams&>(output_params);
-    OptsStrAny new_opts;
+                    OptsStrAny new_opts;
     jpet_options_generator_tools::setOutputFileType(new_opts, "hldRoot");
+
+    if(jpet_options_tools::isOptionSet(fOptions, "firstEvent_int") &&
+       jpet_options_tools::isOptionSet(fOptions, "lastEvent_int")){
+     
+      if( jpet_options_tools::getOptionAsInt(fOptions, "firstEvent_int") != -1 &&
+	  jpet_options_tools::getOptionAsInt(fOptions, "lastEvent_int") != -1 ){
+	jpet_options_generator_tools::setResetEventRangeOption(new_opts, true);
+      }
+    }
+
+    jpet_options_generator_tools::setOutputFile(new_opts, JPetCommonTools::replaceDataTypeInFile(getInputFile(fOptions),"hld"));
+    
     params = JPetParams(new_opts, params.getParamManagerAsShared());
+    
   }
-  
+    
   return true;
 }
 

--- a/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
+++ b/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.cpp
@@ -16,10 +16,11 @@
 #include "./JPetUnzipAndUnpackTask.h"
 #include "../JPetParams/JPetParams.h"
 #include "../JPetOptionsTools/JPetOptionsTools.h"
+#include "../JPetOptionsGenerator/JPetOptionsGeneratorTools.h"
 #include "../JPetCommonTools/JPetCommonTools.h"
 #include "../JPetUnpacker/JPetUnpacker.h"
 
-JPetUnzipAndUnpackTask::JPetUnzipAndUnpackTask(const char* name): JPetTask(name)
+JPetUnzipAndUnpackTask::JPetUnzipAndUnpackTask(const char* name): JPetTask(name), fUnpackHappened(false)
 {
 }
 
@@ -40,6 +41,7 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
 
   if (inputFileType == FileTypeChecker::kHld) {
     unpackFile(inputFile, getTotalEvents(fOptions), unpackerConfigFile, unpackerCalibFile);
+    fUnpackHappened = true;
   }
   /// Assumption that if the file is zipped than it is in the hld format
   /// and we will also unpack if from hld  after unzipping.
@@ -62,8 +64,15 @@ bool JPetUnzipAndUnpackTask::run(const JPetDataInterface&)
   return true;
 }
 
-bool JPetUnzipAndUnpackTask::terminate(JPetParamsInterface&)
+bool JPetUnzipAndUnpackTask::terminate(JPetParamsInterface& output_params)
 {
+  if(fUnpackHappened){
+    auto & params = dynamic_cast<JPetParams&>(output_params);
+    OptsStrAny new_opts;
+    jpet_options_generator_tools::setOutputFileType(new_opts, "hldRoot");
+    params = JPetParams(new_opts, params.getParamManagerAsShared());
+  }
+  
   return true;
 }
 

--- a/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.h
+++ b/JPetUnzipAndUnpackTask/JPetUnzipAndUnpackTask.h
@@ -34,7 +34,7 @@ public:
   static bool unzipFile(const char* filename);
 protected:
   OptsStrAny fOptions;
-   
+  bool fUnpackHappened = false;
   
 };
 #endif /*  !JPETUNZIPANDUNPACKTASK_H */


### PR DESCRIPTION
This PR includes:
* new task registration scheme
* handling of certain parameters from the level of tasks (JPetTaskIO and JPetUnzipAndUnpackTask)

This version is tested with the new examples and every use case seems to work fine for the LargeBarrelAnalysisExample.

However, note that **ScopeLoader and ScopeTask still need to be adapted** and do not work at this point.